### PR TITLE
Add live character counter

### DIFF
--- a/app/components/ValentineCardGenerator.tsx
+++ b/app/components/ValentineCardGenerator.tsx
@@ -27,16 +27,27 @@ export default function ValentineCardGenerator() {
         </div>
 
         <div>
-          <label className="block text-sm font-medium">
-            Personal Message
-          </label>
-          <textarea
-            value={message}
-            onChange={(e) => setMessage(e.target.value)}
-            placeholder="Write your message"
-            className="w-full border rounded p-2"
-          />
-        </div>
+  <label className="block text-sm font-medium">
+    Personal Message
+  </label>
+
+  <textarea
+    value={message}
+    onChange={(e) => {
+      if (e.target.value.length <= 500) {
+        setMessage(e.target.value);
+      }
+    }}
+    placeholder="Write your message"
+    className="w-full border rounded p-2"
+  />
+
+  {/* Character Counter */}
+  <div className="text-sm text-gray-500 mt-1 text-right">
+    {message.length} / 500 characters
+  </div>
+</div>
+
 
       </div>
 


### PR DESCRIPTION
Added a live character counter to the Personal Message text area.

## Changes
- Displays live character count
- Enforces 500 character limit
- Prevents typing beyond limit
- Improves UX with clear feedback

## Issue
Closes #13 
<img width="1852" height="933" alt="Screenshot 2026-02-14 093340" src="https://github.com/user-attachments/assets/430bde45-757b-4328-96dd-72d33b4ddd8f" />

