### PR TITLE
Fix: Connect loveScore algorithm to Love Calculator UI

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -1,5 +1,8 @@
-@import "tailwindcss";
 @import url('https://fonts.googleapis.com/css2?family=Playfair+Display:wght@400;600;700&family=Lato:wght@300;400;700&display=swap');
+
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
 
 .font-display {
   font-family: 'Playfair Display', serif;

--- a/app/love-calculator/page.js
+++ b/app/love-calculator/page.js
@@ -1,5 +1,7 @@
 "use client";
 import { useState } from "react";
+import loveScore from "@/algorithms/loveScore";
+
 
 /*
 Love Compatibility Calculator
@@ -19,16 +21,10 @@ export default function LoveCalculator() {
   const [result, setResult] = useState(null);
 
   const calculateLove = () => {
-    const combined = (name1 + name2).toLowerCase();
-    let score = 0;
+  const percentage = loveScore(name1, name2);
+  setResult(percentage);
+};
 
-    for (let i = 0; i < combined.length; i++) {
-      score += combined.charCodeAt(i);
-    }
-
-    const percentage = score % 101;
-    setResult(percentage);
-  };
 
   const getMessage = (percentage) => {
     if (percentage > 90) return "Made for each other 💖";


### PR DESCRIPTION
Fixes #36


## Problem
The loveScore algorithm existed in algorithms/loveScore.js but was not connected to the frontend UI. The love calculator page was using its own internal algorithm instead.

## Solution
- Imported loveScore from algorithms/loveScore.js
- Replaced inline calculation with centralized algorithm
- Ensured algorithm is now accessible via /love-calculator route
- Fixed globals.css import order to resolve build error

## Result
The loveScore algorithm is now properly integrated and accessible from the application UI.

Tested locally and working correctly.

<img width="1862" height="936" alt="Screenshot 2026-02-14 114147" src="https://github.com/user-attachments/assets/0364c4d9-53e0-4391-9bcc-95caf9410b58" />