### PR TITLE
add Love Quiz navigation card to landing page (issue #80)

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -48,6 +48,15 @@ export default function Home() {
       color: "from-red-500 to-pink-500",
       path: "/truth-or-dare",
     },
+    {
+  id: "love-quiz",
+  title: "Love Quiz",
+  description: "Answer romantic questions and discover your love compatibility score 💕",
+  icon: Heart,
+  color: "from-rose-500 to-pink-500",
+  path: "/love-quiz",
+},
+
 
   ];
 


### PR DESCRIPTION
Added navigation card for the Love Quiz feature on the landing page.

## Changes Made
- Added Love Quiz object to the algorithms array in app/page.tsx
- Configured proper path routing to /love-quiz
- Added title, description, icon, and gradient styling

## Why this fixes the issue
Previously, users could not navigate to the Love Quiz feature from the landing page because there was no navigation card. This change adds the required card and enables navigation.

Fixes #80 
<img width="1833" height="942" alt="image" src="https://github.com/user-attachments/assets/61e59ad6-9310-496c-b8d6-e1bc8462b4fa" />
