### PR TITLE
Fix duplicate icons for navigation cards on homepage (#142)

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -242,21 +242,16 @@ export default function Home() {
                 <div className="relative p-8">
                   
                   {/* Icon */}
-              <div className="mb-6 group-hover:scale-110 transition-transform duration-300">
-                <img
-                  src={
-                    algo.id === "love-calculator"
-                      ? "/calc.webp"
-                      : algo.id === "flames"
-                      ? "/flames.webp"
-                      : algo.id === "nickname-generator"
-                      ? "/nickname.webp"
-                      : "/val-card.webp"
-                  }
-                  alt={algo.title}
-                  className="w-20 h-20 object-contain drop-shadow-md"
-                />
-              </div>
+              {/* Icon */}
+<div className="mb-6 group-hover:scale-110 transition-transform duration-300">
+  {(() => {
+    const Icon = algo.icon;
+    return (
+      <Icon className="w-16 h-16 text-pink-500 drop-shadow-md" />
+    );
+  })()}
+</div>
+
 
 
 


### PR DESCRIPTION
On the homepage, navigation cards were displaying duplicate icons. Only the first few cards showed correct icons, while the remaining cards all displayed the same default image (/val-card.webp).

This happened because the icon rendering logic was hardcoded using conditional image paths instead of using the icon property defined in the algorithms array.

<img width="1822" height="932" alt="image" src="https://github.com/user-attachments/assets/6a449893-554f-4394-936d-913147b12e66" />
