### PR TITLE
Add Lovers Board to homepage navigation (#165)

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -123,7 +123,16 @@ export default function Home() {
       icon: Smile,
       color: "from-pink-500 to-rose-500",
       path: "/pickup-lines",
-    }
+    },
+    {
+  id: "lovers-board",
+  title: "Lovers Board",
+  description: "Post and read anonymous romantic confessions on a vintage notice board",
+  icon: MessageCircle,
+  color: "from-rose-500 to-pink-500",
+  path: "/lovers-board",
+}
+
   ];
 
   const filteredAlgorithms = algorithms.filter(algo =>


### PR DESCRIPTION
## Description
Added the Lovers Board to the homepage navigation by including it in the algorithms array in app/page.tsx.

## Changes made
- Added Lovers Board navigation card
- Linked it to /lovers-board route
- Used consistent styling with other cards

## Why this fixes the issue
This allows users to access the Lovers Board directly from the homepage.

Closes #165
<img width="1840" height="936" alt="image" src="https://github.com/user-attachments/assets/194060dc-8ada-4902-a72f-9ff128af2527" />
