### PR TITLE
Add confirmation dialog before resetting the card

### DIFF
--- a/app/components/ValentineCardGenerator.tsx
+++ b/app/components/ValentineCardGenerator.tsx
@@ -128,12 +128,17 @@ export default function ValentineCardGenerator() {
             {error && <p className="text-sm text-red-500">{error}</p>}
 
             <div className="flex gap-4">
-              <button
-                onClick={handleReset}
-                className="flex-1 border py-3 rounded"
-              >
-                Reset Card
-              </button>
+          <button
+  onClick={() => {
+    if (confirm("Are you sure you want to reset your card?")) {
+      handleReset();
+    }
+  }}
+  className="flex-1 border py-3 rounded"
+>
+  Reset Card
+</button>
+
               <button
                 onClick={() => validateStepOne() && setStep(2)}
                 className="flex-1 bg-[#800020] text-white py-3 rounded"


### PR DESCRIPTION
##  What’s Changed

Added a confirmation dialog before resetting the Valentine card to prevent accidental data loss.

Now, when the user clicks the "Reset Card" button, a confirmation popup appears asking:
"Are you sure you want to reset your card?"

The card will only reset if the user confirms the action.

##  Why This Change?

Previously, clicking "Reset Card" would immediately clear all inputs without warning.  
This update improves user experience by preventing accidental loss of written messages.

##  Impact

- No changes to existing reset logic
- No UI layout changes
- Simple and safe enhancement
- Improves usability

